### PR TITLE
feat: user management admin only control panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+out

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "bracketSpacing": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "htmlWhitespaceSensitivity": "css",
+  "insertPragma": false,
+  "bracketSameLine": false,
+  "proseWrap": "preserve"
+}

--- a/angular.json
+++ b/angular.json
@@ -104,5 +104,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/api/web-api.types.ts
+++ b/src/api/web-api.types.ts
@@ -10,8 +10,10 @@ export type UserPayload = {
   email: string;
   id: number;
   roles: Array<string>;
-}
+};
 
 export type UserProfile = {
   user: UserPayload;
-}
+};
+
+export type UserRole = 'ADMIN';

--- a/src/app/admin/admin-panel/admin-panel.component.ts
+++ b/src/app/admin/admin-panel/admin-panel.component.ts
@@ -1,0 +1,231 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, OnInit } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialog,
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableDataSource, MatTableModule } from '@angular/material/table';
+import { AdminService, User } from '../admin.service';
+import { UserEditDialogComponent } from '../user-edit/user-edit-dialog.component';
+
+@Component({
+  selector: 'app-admin-panel',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTableModule,
+    MatButtonModule,
+    MatIconModule,
+    MatDialogActions,
+    MatDialogContent,
+  ],
+  template: `
+    <div class="admin-panel">
+      <h2 mat-dialog-title>User Management</h2>
+
+      <mat-dialog-content>
+        <div class="table-container">
+          <table mat-table [dataSource]="dataSource" class="mat-elevation-z8">
+            <!-- Email Column -->
+            <ng-container matColumnDef="email">
+              <th mat-header-cell *matHeaderCellDef>Email</th>
+              <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+            </ng-container>
+
+            <!-- Roles Column -->
+            <ng-container matColumnDef="roles">
+              <th mat-header-cell *matHeaderCellDef>Roles</th>
+              <td mat-cell *matCellDef="let user">
+                <div class="role-chips">
+                  <span class="role-chip" *ngFor="let role of user.roles">
+                    {{ role }}
+                  </span>
+                </div>
+              </td>
+            </ng-container>
+
+            <!-- Actions Column -->
+            <ng-container matColumnDef="actions">
+              <th mat-header-cell *matHeaderCellDef>Actions</th>
+              <td mat-cell *matCellDef="let user">
+                <div class="action-buttons">
+                  <button
+                    mat-icon-button
+                    class="edit-button"
+                    (click)="editUser(user)"
+                    matTooltip="Edit User"
+                  >
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                  <button
+                    mat-icon-button
+                    color="warn"
+                    (click)="deleteUser(user.id)"
+                    matTooltip="Delete User"
+                  >
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </div>
+              </td>
+            </ng-container>
+
+            <tr
+              mat-header-row
+              *matHeaderRowDef="displayedColumns; sticky: true"
+            ></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+          </table>
+        </div>
+      </mat-dialog-content>
+
+      <mat-dialog-actions align="end" class="dialog-actions">
+        <button mat-flat-button color="primary" (click)="addNewUser()">
+          <mat-icon>add</mat-icon>
+          Add User
+        </button>
+        <button mat-button mat-dialog-close>Close</button>
+      </mat-dialog-actions>
+    </div>
+  `,
+  styles: [
+    `
+      .admin-panel {
+        padding: 0;
+
+        h2 {
+          margin: 0;
+          padding: 24px 24px 16px;
+          font-size: 24px;
+          font-weight: 500;
+          color: rgba(0, 0, 0, 0.87);
+        }
+      }
+
+      .table-container {
+        position: relative;
+        min-height: 200px;
+        max-height: 400px;
+        overflow: auto;
+        background: white;
+      }
+
+      table {
+        width: 100%;
+        background: white;
+        border-radius: 4px;
+        overflow: hidden;
+
+        th {
+          background: #fafafa;
+          color: rgba(0, 0, 0, 0.87);
+          font-weight: 500;
+          font-size: 14px;
+          padding: 16px;
+        }
+
+        td {
+          padding: 12px 16px;
+          font-size: 14px;
+          color: rgba(0, 0, 0, 0.87);
+        }
+
+        tr:hover {
+          background-color: rgba(0, 0, 0, 0.04);
+        }
+      }
+
+      .role-chips {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+
+        .role-chip {
+          background: #e0e0e0;
+          padding: 4px 12px;
+          border-radius: 16px;
+          font-size: 12px;
+          font-weight: 500;
+          color: rgba(0, 0, 0, 0.87);
+        }
+      }
+
+      .action-buttons {
+        display: flex;
+        gap: 8px;
+
+        .edit-button {
+          color: #1976d2;
+        }
+      }
+
+      .dialog-actions {
+        padding: 16px 24px;
+        background: #fafafa;
+        margin: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.12);
+      }
+
+      mat-dialog-content {
+        padding: 0 24px;
+        margin: 0;
+        max-height: 400px;
+      }
+    `,
+  ],
+})
+export class AdminPanelComponent implements OnInit {
+  private dialog = inject(MatDialog);
+  private dialogRef = inject(MatDialogRef<AdminPanelComponent>);
+  private adminService = inject(AdminService);
+
+  dataSource = new MatTableDataSource<User>([]);
+  displayedColumns = ['email', 'roles', 'actions'];
+
+  ngOnInit() {
+    this.loadUsers();
+  }
+
+  loadUsers() {
+    this.adminService.getUsers().subscribe((users) => {
+      this.dataSource.data = users;
+    });
+  }
+
+  addNewUser() {
+    const dialogRef = this.dialog.open(UserEditDialogComponent, {
+      width: '400px',
+      data: { mode: 'create' },
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.loadUsers();
+      }
+    });
+  }
+
+  editUser(user: User) {
+    const dialogRef = this.dialog.open(UserEditDialogComponent, {
+      width: '400px',
+      data: { mode: 'edit', user },
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.loadUsers();
+      }
+    });
+  }
+
+  deleteUser(id: number) {
+    if (confirm('Are you sure you want to delete this user?')) {
+      this.adminService.deleteUser(id).subscribe(() => {
+        this.loadUsers();
+      });
+    }
+  }
+}

--- a/src/app/admin/admin.service.ts
+++ b/src/app/admin/admin.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../environments/environment';
+import { UserRole } from '../../api/web-api.types';
+
+export interface User {
+  id: number;
+  email: string;
+  roles: UserRole[];
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AdminService {
+  private http = inject(HttpClient);
+  private baseUrl = `${environment.webApiUrl}/users`;
+
+  getUsers() {
+    return this.http.get<User[]>(this.baseUrl);
+  }
+
+  getUser(id: number) {
+    return this.http.get<User>(`${this.baseUrl}/${id}`);
+  }
+
+  createUser(userData: { email: string; password: string; roles: UserRole[] }) {
+    return this.http.post<{ id: number }>(this.baseUrl, userData);
+  }
+
+  updateUserRoles(userId: number, roles: UserRole[]) {
+    return this.http.put<User>(`${this.baseUrl}/${userId}/roles`, { roles });
+  }
+
+  updatePassword(userId: number, password: string) {
+    return this.http.put(`${this.baseUrl}/${userId}/password`, { password });
+  }
+
+  deleteUser(userId: number) {
+    return this.http.delete(`${this.baseUrl}/${userId}`);
+  }
+}

--- a/src/app/admin/admin.service.ts
+++ b/src/app/admin/admin.service.ts
@@ -33,7 +33,11 @@ export class AdminService {
   }
 
   updatePassword(userId: number, password: string) {
-    return this.http.put(`${this.baseUrl}/${userId}/password`, { password });
+    return this.http.put(
+      `${this.baseUrl}/${userId}/password`,
+      { password },
+      { responseType: 'text' }
+    );
   }
 
   deleteUser(userId: number) {

--- a/src/app/admin/user-create/create-user.component.ts
+++ b/src/app/admin/user-create/create-user.component.ts
@@ -1,0 +1,268 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, DestroyRef, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { catchError, finalize, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { UserRole } from '../../../api/web-api.types';
+import { AdminService } from '../admin.service';
+import { MatIconModule } from '@angular/material/icon';
+
+interface CreateUserForm {
+  email: FormControl<string>;
+  password: FormControl<string>;
+  roles: FormControl<UserRole[]>;
+}
+
+@Component({
+  selector: 'app-admin-create-user-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    ReactiveFormsModule,
+    MatIconModule,
+  ],
+  template: `
+    <div class="create-user-dialog">
+      <h2 matDialogTitle>Create a new User</h2>
+
+      <form [formGroup]="userForm" (ngSubmit)="onSubmit()">
+        <mat-dialog-content>
+          <div class="form-fields">
+            <mat-form-field appearance="outline">
+              <mat-label>Email Address</mat-label>
+              <input
+                matInput
+                formControlName="email"
+                type="email"
+                autocomplete="email"
+                [attr.aria-label]="'Email address'"
+              />
+              <mat-error *ngIf="email.errors?.['required']">
+                Email is required
+              </mat-error>
+              <mat-error *ngIf="email.errors?.['email']">
+                Please enter a valid email address
+              </mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>Password</mat-label>
+              <input
+                matInput
+                formControlName="password"
+                [type]="hidePassword ? 'password' : 'text'"
+                autocomplete="new-password"
+                [attr.aria-label]="'Password'"
+              />
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                (click)="hidePassword = !hidePassword"
+                [attr.aria-label]="'Toggle password visibility'"
+              >
+                <mat-icon>{{
+                  hidePassword ? 'visibility_off' : 'visibility'
+                }}</mat-icon>
+              </button>
+              <mat-error *ngIf="password.errors?.['required']">
+                Password is required
+              </mat-error>
+              <mat-error *ngIf="password.errors?.['minlength']">
+                Password must be at least 8 characters
+              </mat-error>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline">
+              <mat-label>User Roles</mat-label>
+              <mat-select
+                formControlName="roles"
+                multiple
+                [attr.aria-label]="'Select user roles'"
+              >
+                <mat-option *ngFor="let role of availableRoles" [value]="role">
+                  {{ role | titlecase }}
+                </mat-option>
+              </mat-select>
+              <mat-error *ngIf="roles.errors?.['required']">
+                Please select at least one role
+              </mat-error>
+            </mat-form-field>
+          </div>
+        </mat-dialog-content>
+
+        <mat-dialog-actions align="end">
+          <button
+            mat-button
+            mat-dialog-close
+            type="button"
+            [disabled]="isSubmitting()"
+          >
+            Cancel
+          </button>
+          <button
+            mat-flat-button
+            color="primary"
+            type="submit"
+            [disabled]="!userForm.valid || isSubmitting()"
+          >
+            <span class="button-content">
+              <mat-spinner
+                *ngIf="isSubmitting()"
+                diameter="20"
+                class="spinner"
+              ></mat-spinner>
+              {{ isSubmitting() ? 'Creating...' : 'Create User' }}
+            </span>
+          </button>
+        </mat-dialog-actions>
+      </form>
+    </div>
+  `,
+  styles: [
+    `
+      .create-user-dialog {
+        mat-dialog-title {
+          margin: 0;
+          padding: 24px 24px 0;
+          font-size: 24px;
+          font-weight: 500;
+          color: rgba(0, 0, 0, 0.87);
+        }
+
+        mat-dialog-content {
+          padding: 24px;
+          margin: 0;
+          min-width: 400px;
+          max-width: 100%;
+          box-sizing: border-box;
+        }
+
+        .form-fields {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        mat-form-field {
+          width: 100%;
+        }
+
+        mat-dialog-actions {
+          padding: 16px 24px;
+          background: #fafafa;
+          margin: 0;
+          border-top: 1px solid rgba(0, 0, 0, 0.12);
+        }
+
+        .button-content {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .spinner {
+          margin-right: 8px;
+        }
+
+        @media (max-width: 600px) {
+          mat-dialog-content {
+            min-width: unset;
+            width: 100%;
+          }
+        }
+      }
+    `,
+  ],
+})
+export class AdminCreateUserDialogComponent {
+  private readonly adminService = inject(AdminService);
+  private readonly dialogRef = inject(
+    MatDialogRef<AdminCreateUserDialogComponent>
+  );
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly availableRoles: UserRole[] = ['ADMIN'];
+  readonly isSubmitting = signal(false);
+  hidePassword = true;
+
+  userForm = new FormGroup<CreateUserForm>({
+    email: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.email],
+    }),
+    password: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(8)],
+    }),
+    roles: new FormControl<UserRole[]>([], {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  // Getter methods for form controls
+  get email() {
+    return this.userForm.get('email') as FormControl;
+  }
+  get password() {
+    return this.userForm.get('password') as FormControl;
+  }
+  get roles() {
+    return this.userForm.get('roles') as FormControl;
+  }
+
+  onSubmit(): void {
+    if (this.userForm.valid && !this.isSubmitting()) {
+      this.isSubmitting.set(true);
+
+      const userData = {
+        email: this.email.value,
+        password: this.password.value,
+        roles: this.roles.value,
+      };
+
+      this.adminService
+        .createUser(userData)
+        .pipe(
+          takeUntilDestroyed(this.destroyRef),
+          tap(() => {
+            this.snackBar.open('User created successfully', 'Close', {
+              duration: 3000,
+            });
+            this.dialogRef.close(true);
+          }),
+          catchError((error) => {
+            this.snackBar.open(
+              error.message || 'Failed to create user. Please try again.',
+              'Close',
+              { duration: 5000 }
+            );
+            return of(null);
+          }),
+          finalize(() => this.isSubmitting.set(false))
+        )
+        .subscribe();
+    }
+  }
+}

--- a/src/app/admin/user-edit/user-edit-dialog.component.ts
+++ b/src/app/admin/user-edit/user-edit-dialog.component.ts
@@ -1,0 +1,161 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject, inject } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { UserRole } from '../../../api/web-api.types';
+import { AdminService } from '../admin.service';
+
+@Component({
+  selector: 'app-user-edit-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    ReactiveFormsModule,
+    MatDialogActions,
+    MatDialogContent,
+  ],
+  template: `
+    <div class="edit-dialog">
+      <h2 mat-dialog-title>
+        {{ data.mode === 'create' ? 'Create User' : 'Edit User' }}
+      </h2>
+
+      <form [formGroup]="userForm" (ngSubmit)="onSubmit()">
+        <mat-dialog-content>
+          <mat-form-field appearance="outline">
+            <mat-label>Email</mat-label>
+            <input matInput formControlName="email" type="email" />
+            <mat-error *ngIf="userForm.get('email')?.errors?.['required']">
+              Email is required
+            </mat-error>
+            <mat-error *ngIf="userForm.get('email')?.errors?.['email']">
+              Please enter a valid email
+            </mat-error>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Password</mat-label>
+            <input matInput formControlName="password" type="password" />
+            <mat-error *ngIf="userForm.get('password')?.errors?.['required']">
+              Password is required for new users
+            </mat-error>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Roles</mat-label>
+            <mat-select formControlName="roles" multiple>
+              <mat-option *ngFor="let role of availableRoles" [value]="role">
+                {{ role }}
+              </mat-option>
+            </mat-select>
+          </mat-form-field>
+        </mat-dialog-content>
+
+        <mat-dialog-actions align="end" class="dialog-actions">
+          <button mat-button mat-dialog-close>Cancel</button>
+          <button
+            mat-flat-button
+            color="primary"
+            type="submit"
+            [disabled]="!userForm.valid"
+          >
+            {{ data.mode === 'create' ? 'Create' : 'Update' }}
+          </button>
+        </mat-dialog-actions>
+      </form>
+    </div>
+  `,
+  styles: [
+    `
+      .edit-dialog {
+        h2 {
+          margin: 0;
+          padding: 24px 24px 16px;
+          font-size: 24px;
+          font-weight: 500;
+          color: rgba(0, 0, 0, 0.87);
+        }
+      }
+
+      mat-dialog-content {
+        padding: 0 24px;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        min-width: 400px;
+      }
+
+      mat-form-field {
+        width: 100%;
+      }
+
+      .dialog-actions {
+        padding: 16px 24px;
+        background: #fafafa;
+        margin: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.12);
+      }
+    `,
+  ],
+})
+export class UserEditDialogComponent {
+  private adminService = inject(AdminService);
+  private dialogRef = inject(MatDialogRef<UserEditDialogComponent>);
+  public availableRoles: UserRole[] = ['ADMIN'];
+
+  @Inject(MAT_DIALOG_DATA) public data: {
+    mode: 'create';
+    user?: any;
+  } = { mode: 'create', user: {} };
+
+  userForm = new FormGroup({
+    email: new FormControl('', [Validators.required, Validators.email]),
+    password: new FormControl(''),
+    roles: new FormControl<UserRole[]>([], Validators.required),
+  });
+
+  ngOnInit() {
+    if (this.data.user) {
+      this.userForm.patchValue({
+        email: this.data.user.email,
+        roles: this.data.user.roles,
+      });
+    }
+  }
+
+  onSubmit() {
+    if (this.userForm.valid) {
+      const userData = this.userForm.value;
+
+      const filledOutData = {
+        email: userData.email!,
+        password: userData.password!,
+        roles: userData.roles!,
+      };
+      const operation = this.adminService.createUser(filledOutData);
+
+      operation.subscribe(() => {
+        this.dialogRef.close(true);
+      });
+    }
+  }
+}

--- a/src/app/admin/user-update-password/update-password.component.ts
+++ b/src/app/admin/user-update-password/update-password.component.ts
@@ -1,0 +1,221 @@
+import { CommonModule } from '@angular/common';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { of } from 'rxjs';
+import { catchError, finalize, tap } from 'rxjs/operators';
+import { AdminService, User } from '../admin.service';
+
+interface UpdatePasswordForm {
+  password: FormControl<string>;
+}
+
+@Component({
+  selector: 'admin-update-password-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatProgressSpinnerModule,
+    ReactiveFormsModule,
+    MatIconModule,
+  ],
+  template: `
+    <div class="update-password-dialog">
+      <h2 matDialogTitle>Update User Password</h2>
+
+      <form [formGroup]="userForm" (ngSubmit)="onSubmit()">
+        <mat-dialog-content>
+          <div class="form-fields">
+            <mat-form-field appearance="outline">
+              <mat-label>New Password</mat-label>
+              <input
+                matInput
+                formControlName="password"
+                [type]="hidePassword ? 'password' : 'text'"
+                autocomplete="new-password"
+                [attr.aria-label]="'Password'"
+              />
+              <button
+                mat-icon-button
+                matSuffix
+                type="button"
+                (click)="hidePassword = !hidePassword"
+                [attr.aria-label]="'Toggle password visibility'"
+              >
+                <mat-icon>{{
+                  hidePassword ? 'visibility_off' : 'visibility'
+                }}</mat-icon>
+              </button>
+              <mat-error *ngIf="password.errors?.['required']">
+                Password is required
+              </mat-error>
+              <mat-error *ngIf="password.errors?.['minlength']">
+                Password must be at least 8 characters
+              </mat-error>
+            </mat-form-field>
+          </div>
+        </mat-dialog-content>
+
+        <mat-dialog-actions align="end">
+          <button
+            mat-button
+            mat-dialog-close
+            type="button"
+            [disabled]="isSubmitting()"
+          >
+            Cancel
+          </button>
+          <button
+            mat-flat-button
+            color="primary"
+            type="submit"
+            [disabled]="!userForm.valid || isSubmitting()"
+          >
+            <span class="button-content">
+              <mat-spinner
+                *ngIf="isSubmitting()"
+                diameter="20"
+                class="spinner"
+              ></mat-spinner>
+              {{ isSubmitting() ? 'Updating...' : 'Submit' }}
+            </span>
+          </button>
+        </mat-dialog-actions>
+      </form>
+    </div>
+  `,
+  styles: [
+    `
+      .update-password-dialog {
+        mat-dialog-title {
+          margin: 0;
+          padding: 24px 24px 0;
+          font-size: 24px;
+          font-weight: 500;
+          color: rgba(0, 0, 0, 0.87);
+        }
+
+        mat-dialog-content {
+          padding: 24px;
+          margin: 0;
+          min-width: 400px;
+          max-width: 100%;
+          box-sizing: border-box;
+        }
+
+        .form-fields {
+          display: flex;
+          flex-direction: column;
+          gap: 16px;
+        }
+
+        mat-form-field {
+          width: 100%;
+        }
+
+        mat-dialog-actions {
+          padding: 16px 24px;
+          background: #fafafa;
+          margin: 0;
+          border-top: 1px solid rgba(0, 0, 0, 0.12);
+        }
+
+        .button-content {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+        }
+
+        .spinner {
+          margin-right: 8px;
+        }
+
+        @media (max-width: 600px) {
+          mat-dialog-content {
+            min-width: unset;
+            width: 100%;
+          }
+        }
+      }
+    `,
+  ],
+})
+export class AdminUpdateUserPasswordDialogComponent {
+  private readonly adminService = inject(AdminService);
+  private readonly dialogRef = inject(
+    MatDialogRef<AdminUpdateUserPasswordDialogComponent>
+  );
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly data = inject<{ user: User }>(MAT_DIALOG_DATA);
+
+  readonly isSubmitting = signal(false);
+  hidePassword = true;
+
+  userForm = new FormGroup<UpdatePasswordForm>({
+    password: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(8)],
+    }),
+  });
+
+  // Getter methods for form controls
+  get password() {
+    return this.userForm.get('password') as FormControl;
+  }
+
+  onSubmit(): void {
+    if (this.userForm.valid && !this.isSubmitting()) {
+      this.isSubmitting.set(true);
+
+      const userData = {
+        password: this.password.value,
+      };
+
+      this.adminService
+        .updatePassword(this.data.user.id, userData.password)
+        .pipe(
+          takeUntilDestroyed(this.destroyRef),
+          tap(() => {
+            this.snackBar.open('User password updated successfully', 'Close', {
+              duration: 3000,
+            });
+            this.dialogRef.close(true);
+          }),
+          catchError((error) => {
+            this.snackBar.open(
+              error.message ||
+                'Failed to update user password. Please try again.',
+              'Close',
+              { duration: 5000 }
+            );
+            return of(null);
+          }),
+          finalize(() => this.isSubmitting.set(false))
+        )
+        .subscribe();
+    }
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,19 +1,25 @@
-import {ApplicationConfig, provideExperimentalZonelessChangeDetection} from '@angular/core';
-import {provideRouter, withComponentInputBinding} from '@angular/router';
+import {
+  ApplicationConfig,
+  provideExperimentalZonelessChangeDetection,
+} from '@angular/core';
+import { provideRouter, withComponentInputBinding } from '@angular/router';
 
-import {routes} from './app.routes';
-import {provideAnimationsAsync} from '@angular/platform-browser/animations/async';
-import {provideHttpClient, withFetch, withInterceptors} from '@angular/common/http';
-import {authInterceptor} from "./auth/auth-http-interceptor";
+import { routes } from './app.routes';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import {
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+} from '@angular/common/http';
+import { authInterceptor } from './auth/auth-http-interceptor';
+import { AdminService } from './admin/admin.service';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideExperimentalZonelessChangeDetection(),
     provideRouter(routes, withComponentInputBinding()),
     provideAnimationsAsync(),
-    provideHttpClient(
-      withFetch(),
-      withInterceptors([authInterceptor])
-    )
-  ]
+    provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
+    AdminService,
+  ],
 };

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,9 +1,9 @@
-import { inject, Injectable, Signal, signal } from '@angular/core';
-import { WebApiService } from '../../api/web-api.service';
-import { UserPayload, UserProfile } from '../../api/web-api.types';
-import { map, Observable, of, retry, switchMap } from 'rxjs';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { jwtDecode, JwtPayload } from 'jwt-decode';
+import {inject, Injectable, Signal, signal} from '@angular/core';
+import {WebApiService} from '../../api/web-api.service';
+import {UserPayload, UserProfile} from '../../api/web-api.types';
+import {map, Observable, of, retry, switchMap} from 'rxjs';
+import {toObservable} from '@angular/core/rxjs-interop';
+import {jwtDecode, JwtPayload} from 'jwt-decode';
 
 export type AuthenticatedUser = {
   user: UserPayload;
@@ -34,7 +34,7 @@ export class AuthService {
   user$: Observable<UserPayload | undefined> = toObservable(
     this._authenticated
   ).pipe(
-    map((isAuthenticated) => {
+    map(isAuthenticated => {
       return this.auth?.user;
     })
   );
@@ -46,7 +46,7 @@ export class AuthService {
   profile$: Observable<UserProfile | undefined> = toObservable(
     this._authenticated
   ).pipe(
-    switchMap((isAuthenticated) => {
+    switchMap(isAuthenticated => {
       if (isAuthenticated) {
         return this.api.getProfile();
       } else {
@@ -67,8 +67,8 @@ export class AuthService {
   }
 
   login(email: string, password: string): Observable<void> {
-    return this.api.login({ email, password }).pipe(
-      map((auth) => {
+    return this.api.login({email, password}).pipe(
+      map(auth => {
         if (this.onAuth(auth.token, auth.refreshToken)) {
           this.store();
         }
@@ -84,7 +84,7 @@ export class AuthService {
    */
   isAdmin(): Observable<boolean> {
     return this.user$.pipe(
-      map((user) => {
+      map(user => {
         if (!user) {
           return false;
         }
@@ -153,14 +153,14 @@ export class AuthService {
 
     this.api
       .refreshToken(auth.refreshToken)
-      .pipe(retry({ count: 2, delay: 2_000 }))
+      .pipe(retry({count: 2, delay: 2_000}))
       .subscribe({
-        next: (newToken) => {
+        next: newToken => {
           console.log('refreshed token');
           this.onAuth(newToken, auth.refreshToken);
           this.store();
         },
-        error: (err) => {
+        error: err => {
           console.error('Refresh token failed!', err);
           this.unauthenticated();
         },
@@ -233,7 +233,7 @@ export class AuthService {
     if (this.auth === undefined) {
       return;
     }
-    const { token, refreshToken } = this.auth;
+    const {token, refreshToken} = this.auth;
     localStorage.setItem(this.lsToken, token);
     localStorage.setItem(this.lsRefreshToken, refreshToken);
   }

--- a/src/app/auth/login-dialog/login-dialog.component.ts
+++ b/src/app/auth/login-dialog/login-dialog.component.ts
@@ -1,22 +1,22 @@
-import { Component, inject, signal } from '@angular/core';
+import {Component, inject, signal} from '@angular/core';
 import {
   FormControl,
   FormGroup,
   ReactiveFormsModule,
   Validators,
 } from '@angular/forms';
-import { MatButton } from '@angular/material/button';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { merge, take } from 'rxjs';
-import { extractErrorMessage } from '../../../api/api-util';
-import { WebApiService } from '../../../api/web-api.service';
-import { AuthService } from '../auth.service';
+import {MatButton} from '@angular/material/button';
+import {MatDialogModule, MatDialogRef} from '@angular/material/dialog';
+import {MatFormFieldModule} from '@angular/material/form-field';
+import {MatInputModule} from '@angular/material/input';
+import {merge, take} from 'rxjs';
+import {extractErrorMessage} from '../../../api/api-util';
+import {WebApiService} from '../../../api/web-api.service';
+import {AuthService} from '../auth.service';
 
 type Modes = 'register' | 'login';
 
-type Credentials = { email: string; password: string };
+type Credentials = {email: string; password: string};
 
 @Component({
   selector: 'app-login-dialog',
@@ -75,7 +75,7 @@ export class LoginDialogComponent {
         this.busy.set(false);
         this.dialogRef.close();
       },
-      error: (err) => this.handleError(err),
+      error: err => this.handleError(err),
     });
   }
 
@@ -87,7 +87,7 @@ export class LoginDialogComponent {
         console.log('registered, logging in', value.email);
         this.login(value);
       },
-      error: (err) => this.handleError(err),
+      error: err => this.handleError(err),
     });
   }
 
@@ -96,7 +96,7 @@ export class LoginDialogComponent {
     const errorMessage = extractErrorMessage(error);
     this.errorMessage.set(errorMessage);
 
-    const { email, password } = this.form.controls;
+    const {email, password} = this.form.controls;
 
     if (this.emailErrors.includes(errorMessage)) {
       email.setErrors({
@@ -124,7 +124,7 @@ export class LoginDialogComponent {
    * which clears custom errors on controls.
    */
   private resetErrors() {
-    const { email, password } = this.form.controls;
+    const {email, password} = this.form.controls;
     this.errorMessage.set(undefined);
     email.updateValueAndValidity();
     password.updateValueAndValidity();

--- a/src/app/auth/login-dialog/login-dialog.component.ts
+++ b/src/app/auth/login-dialog/login-dialog.component.ts
@@ -1,31 +1,42 @@
-import {Component, inject, signal} from '@angular/core';
-import {MatDialogModule, MatDialogRef} from "@angular/material/dialog";
-import {MatButton} from "@angular/material/button";
-import {MatFormFieldModule} from "@angular/material/form-field";
-import {MatInputModule} from "@angular/material/input";
-import {WebApiService} from "../../../api/web-api.service";
-import {FormControl, FormGroup, ReactiveFormsModule, Validators} from "@angular/forms";
-import {AuthService} from "../auth.service";
-import {extractErrorMessage} from "../../../api/api-util";
-import {merge, take} from "rxjs";
+import { Component, inject, signal } from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { MatButton } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { merge, take } from 'rxjs';
+import { extractErrorMessage } from '../../../api/api-util';
+import { WebApiService } from '../../../api/web-api.service';
+import { AuthService } from '../auth.service';
 
-type Modes = "register" | "login";
+type Modes = 'register' | 'login';
 
 type Credentials = { email: string; password: string };
 
 @Component({
   selector: 'app-login-dialog',
   standalone: true,
-  imports: [MatDialogModule, MatButton, ReactiveFormsModule, MatFormFieldModule, MatInputModule],
+  imports: [
+    MatDialogModule,
+    MatButton,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
   templateUrl: './login-dialog.component.html',
-  styleUrl: './login-dialog.component.scss'
+  styleUrl: './login-dialog.component.scss',
 })
 export class LoginDialogComponent {
   readonly dialogRef = inject(MatDialogRef<LoginDialogComponent>);
   readonly authService = inject(AuthService);
   readonly api = inject(WebApiService);
 
-  mode = signal<Modes>("login");
+  mode = signal<Modes>('login');
 
   busy = signal(false);
 
@@ -33,14 +44,11 @@ export class LoginDialogComponent {
 
   form = new FormGroup({
     email: new FormControl('', Validators.required),
-    password: new FormControl('', Validators.required)
+    password: new FormControl('', Validators.required),
   });
 
   // error messages related to the email input.
-  private emailErrors = [
-    'Invalid email',
-    'User already exists'
-  ];
+  private emailErrors = ['Invalid email', 'User already exists'];
 
   onSubmit() {
     this.resetErrors();
@@ -67,7 +75,7 @@ export class LoginDialogComponent {
         this.busy.set(false);
         this.dialogRef.close();
       },
-      error: err => this.handleError(err)
+      error: (err) => this.handleError(err),
     });
   }
 
@@ -79,31 +87,29 @@ export class LoginDialogComponent {
         console.log('registered, logging in', value.email);
         this.login(value);
       },
-      error: err => this.handleError(err)
+      error: (err) => this.handleError(err),
     });
   }
 
   private handleError(error: any) {
     this.busy.set(false);
-    const errorMessage = extractErrorMessage(error)
+    const errorMessage = extractErrorMessage(error);
     this.errorMessage.set(errorMessage);
 
-    const {email, password} = this.form.controls;
+    const { email, password } = this.form.controls;
 
     if (this.emailErrors.includes(errorMessage)) {
       email.setErrors({
-        invalid: true
+        invalid: true,
       });
       // clear error message on next change.
-      email.valueChanges
-        .pipe(take(1))
-        .subscribe(() => this.resetErrors());
+      email.valueChanges.pipe(take(1)).subscribe(() => this.resetErrors());
     } else if (errorMessage === 'Invalid credentials') {
       email.setErrors({
-        invalid: true
+        invalid: true,
       });
       password.setErrors({
-        invalid: true
+        invalid: true,
       });
       // in this case user only needs to fix one input, but form will
       // remain invalid until user changes both.
@@ -118,7 +124,7 @@ export class LoginDialogComponent {
    * which clears custom errors on controls.
    */
   private resetErrors() {
-    const {email, password} = this.form.controls;
+    const { email, password } = this.form.controls;
     this.errorMessage.set(undefined);
     email.updateValueAndValidity();
     password.updateValueAndValidity();

--- a/src/app/location-selection/location-selection.component.html
+++ b/src/app/location-selection/location-selection.component.html
@@ -1,71 +1,87 @@
-@let busyRegions = mapService.criteriaRequest()?.busyRegions$ | async ;
-@let isBusy = busyRegions && busyRegions.size > 0 ;
+@let busyRegions = mapService.criteriaRequest()?.busyRegions$ | async ; @let
+isBusy = busyRegions && busyRegions.size > 0 ;
 <mat-drawer-container hasBackdrop="false" class="reef-guide">
   <mat-drawer #drawer>
-    @switch (drawerMode()) {
-      @case ('criteria') {
-        <div class="drawer-content">
-          <mat-toolbar>
-            <span>Criteria</span>
-            <button mat-button (click)="criteria.reset()"
-                    matTooltip="Reset all criteria to min/max">Reset
-            </button>
-            <button mat-icon-button (click)="drawer.toggle(false)">
-              <mat-icon>close</mat-icon>
-            </button>
-          </mat-toolbar>
-          <app-selection-criteria #criteria></app-selection-criteria>
-          <mat-toolbar>
-            @if (isBusy) {
-              <button mat-stroked-button (click)="mapService.cancelCriteriaRequest()">Cancel</button>
+    @switch (drawerMode()) { @case ('criteria') {
+    <div class="drawer-content">
+      <mat-toolbar>
+        <span>Criteria</span>
+        <button
+          mat-button
+          (click)="criteria.reset()"
+          matTooltip="Reset all criteria to min/max"
+        >
+          Reset
+        </button>
+        <button mat-icon-button (click)="drawer.toggle(false)">
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-toolbar>
+      <app-selection-criteria #criteria></app-selection-criteria>
+      <mat-toolbar>
+        @if (isBusy) {
+        <button mat-stroked-button (click)="mapService.cancelCriteriaRequest()">
+          Cancel
+        </button>
 
-            } @else if (mapService.showClear()) {
-              <button mat-button (click)="mapService.clearAssessedLayers()">Clear</button>
-            }
-            <span style="flex: auto"></span>
-            @if (config.mockCOGS() && config.assessLayerTypes().includes('cog')) {
-              <mat-icon color="warn"
-                        matTooltip="using mock COGS, criteria have no effect on COG layer">
-                warning
-              </mat-icon>
-            }
-            @if (isBusy) {
-              <mat-progress-spinner mode="indeterminate" diameter="32"
-                                    [matTooltip]="getLoadingRegionsMessage(busyRegions!)">
-              </mat-progress-spinner>
-            }
-            <button mat-flat-button
-                    [disabled]="isBusy"
-                    (click)="onAssess(criteria.getCriteria())">Assess
-            </button>
-          </mat-toolbar>
-        </div>
-      }
-      @case ('style') {
-        <mat-toolbar>
-          <span>Layer Styling</span>
-          <button mat-icon-button (click)="drawer.toggle(false)">
-            <mat-icon>close</mat-icon>
-          </button>
-        </mat-toolbar>
-        <div class="styling-content">
-          <mat-accordion>
-            @for (layer of mapService.styledLayers(); track layer.id) {
-              <mat-expansion-panel>
-                <mat-expansion-panel-header>{{ layer.title }}</mat-expansion-panel-header>
-                <ng-template matExpansionPanelContent>
-                  <app-layer-style-editor [layer]="layer"></app-layer-style-editor>
-                </ng-template>
-              </mat-expansion-panel>
-            }
-          </mat-accordion>
-        </div>
-      }
-    }
+        } @else if (mapService.showClear()) {
+        <button mat-button (click)="mapService.clearAssessedLayers()">
+          Clear
+        </button>
+        }
+        <span style="flex: auto"></span>
+        @if (config.mockCOGS() && config.assessLayerTypes().includes('cog')) {
+        <mat-icon
+          color="warn"
+          matTooltip="using mock COGS, criteria have no effect on COG layer"
+        >
+          warning
+        </mat-icon>
+        } @if (isBusy) {
+        <mat-progress-spinner
+          mode="indeterminate"
+          diameter="32"
+          [matTooltip]="getLoadingRegionsMessage(busyRegions!)"
+        >
+        </mat-progress-spinner>
+        }
+        <button
+          mat-flat-button
+          [disabled]="isBusy"
+          (click)="onAssess(criteria.getCriteria())"
+        >
+          Assess
+        </button>
+      </mat-toolbar>
+    </div>
+    } @case ('style') {
+    <mat-toolbar>
+      <span>Layer Styling</span>
+      <button mat-icon-button (click)="drawer.toggle(false)">
+        <mat-icon>close</mat-icon>
+      </button>
+    </mat-toolbar>
+    <div class="styling-content">
+      <mat-accordion>
+        @for (layer of mapService.styledLayers(); track layer.id) {
+        <mat-expansion-panel>
+          <mat-expansion-panel-header>{{
+            layer.title
+          }}</mat-expansion-panel-header>
+          <ng-template matExpansionPanelContent>
+            <app-layer-style-editor [layer]="layer"></app-layer-style-editor>
+          </ng-template>
+        </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </div>
+    } }
   </mat-drawer>
   <mat-drawer-content>
-    <arcgis-map [itemId]="config.arcgisMapItemId()"
-                (arcgisViewClick)="arcgisViewClick($event)">
+    <arcgis-map
+      [itemId]="config.arcgisMapItemId()"
+      (arcgisViewClick)="arcgisViewClick($event)"
+    >
       <!-- TODO buttons not stacking when bottom-right, user could just browser-fullscreen -->
       <!--      <arcgis-fullscreen position="bottom-right"></arcgis-fullscreen>-->
       <arcgis-zoom position="bottom-right"></arcgis-zoom>
@@ -76,51 +92,82 @@
         <arcgis-legend></arcgis-legend>
       </arcgis-expand>
     </arcgis-map>
-    @if (authService.authenticated()) {
-      @let user = authService.user$ | async ;
-      <div class="map-buttons">
-        <div class="row">
-          <button mat-mini-fab (click)="openDrawer('criteria')"
-                  matTooltipPosition="right" matTooltip="Adjust criteria">
-            <mat-icon>linear_scale</mat-icon>
-          </button>
-          @if (isBusy) {
-            <mat-progress-spinner class="criteria-spinner"
-                                  mode="indeterminate" diameter="32"
-                                  [matTooltip]="getLoadingRegionsMessage(busyRegions!)">
-            </mat-progress-spinner>
-          }
-        </div>
-        <button mat-mini-fab (click)="openDrawer('style')"
-                matTooltipPosition="right" matTooltip="Layer Style">
-          <mat-icon>brush</mat-icon>
+    @if (authService.authenticated()) { @let user = authService.user$ | async ;
+    <div class="map-buttons">
+      <div class="row">
+        <button
+          mat-mini-fab
+          (click)="openDrawer('criteria')"
+          matTooltipPosition="right"
+          matTooltip="Adjust criteria"
+        >
+          <mat-icon>linear_scale</mat-icon>
         </button>
-        <button mat-mini-fab (click)="openConfig()"
-                matTooltipPosition="right" matTooltip="Configuration">
-          <mat-icon>settings</mat-icon>
-        </button>
-      </div>
-      <div class="center-container">
-        @let progress = mapService.progress$ | async;
-        @if (progress != null) {
-        <mat-progress-bar class="layer-progress" [value]="progress * 100"
-                          [style.visibility]="progress === 1 ? 'hidden':'visible'">
-        </mat-progress-bar>
+        @if (isBusy) {
+        <mat-progress-spinner
+          class="criteria-spinner"
+          mode="indeterminate"
+          diameter="32"
+          [matTooltip]="getLoadingRegionsMessage(busyRegions!)"
+        >
+        </mat-progress-spinner>
         }
       </div>
-
-      <button class="profile-button" mat-mini-fab [matMenuTriggerFor]="profileMenu"
-              [matTooltip]="user?.email" matTooltipPosition="left">
-        <mat-icon>account_circle</mat-icon>
+      <button
+        mat-mini-fab
+        (click)="openDrawer('style')"
+        matTooltipPosition="right"
+        matTooltip="Layer Style"
+      >
+        <mat-icon>brush</mat-icon>
       </button>
-      <mat-menu #profileMenu="matMenu">
-        <button mat-menu-item (click)="authService.logout()">
-          <mat-icon>logout</mat-icon>
-          <span>Logout</span>
-        </button>
-      </mat-menu>
+      <button
+        mat-mini-fab
+        (click)="openConfig()"
+        matTooltipPosition="right"
+        matTooltip="Configuration"
+      >
+        <mat-icon>settings</mat-icon>
+      </button>
+      <button
+        mat-mini-fab
+        *ngIf="((authService.user$ | async)?.roles ?? []).includes('ADMIN')"
+        (click)="openAdminPanel()"
+        matTooltip="User Management"
+      >
+        <mat-icon>admin_panel_settings</mat-icon>
+      </button>
+    </div>
+    <div class="center-container">
+      @let progress = mapService.progress$ | async; @if (progress != null) {
+      <mat-progress-bar
+        class="layer-progress"
+        [value]="progress * 100"
+        [style.visibility]="progress === 1 ? 'hidden' : 'visible'"
+      >
+      </mat-progress-bar>
+      }
+    </div>
+
+    <button
+      class="profile-button"
+      mat-mini-fab
+      [matMenuTriggerFor]="profileMenu"
+      [matTooltip]="user?.email"
+      matTooltipPosition="left"
+    >
+      <mat-icon>account_circle</mat-icon>
+    </button>
+    <mat-menu #profileMenu="matMenu">
+      <button mat-menu-item (click)="authService.logout()">
+        <mat-icon>logout</mat-icon>
+        <span>Logout</span>
+      </button>
+    </mat-menu>
     } @else {
-      <button class="profile-button" mat-raised-button (click)="openLogin()">Login</button>
+    <button class="profile-button" mat-raised-button (click)="openLogin()">
+      Login
+    </button>
     }
   </mat-drawer-content>
 </mat-drawer-container>

--- a/src/app/location-selection/location-selection.component.ts
+++ b/src/app/location-selection/location-selection.component.ts
@@ -1,25 +1,38 @@
-import {AfterViewInit, Component, inject, signal, ViewChild} from '@angular/core';
-import {MatDrawer, MatSidenavModule} from "@angular/material/sidenav";
-import {ArcgisMap, ComponentLibraryModule} from "@arcgis/map-components-angular";
-import {ArcgisMapCustomEvent} from "@arcgis/map-components";
-import {MatButtonModule} from "@angular/material/button";
-import {MatIconModule} from "@angular/material/icon";
-import {MatToolbarModule} from "@angular/material/toolbar";
-import {SelectionCriteria, SelectionCriteriaComponent} from "./selection-criteria/selection-criteria.component";
-import {ReefGuideApiService} from "./reef-guide-api.service";
-import {MatTooltip} from "@angular/material/tooltip";
-import {MatDialog} from "@angular/material/dialog";
-import {ConfigDialogComponent} from "./config-dialog/config-dialog.component";
-import {ReefGuideConfigService} from "./reef-guide-config.service";
-import {AsyncPipe} from "@angular/common";
-import {MatProgressSpinner} from "@angular/material/progress-spinner";
-import {LayerStyleEditorComponent} from "../widgets/layer-style-editor/layer-style-editor.component";
-import {ReefGuideMapService} from "./reef-guide-map.service";
-import {MatAccordion, MatExpansionModule} from "@angular/material/expansion";
-import {LoginDialogComponent} from "../auth/login-dialog/login-dialog.component";
-import {AuthService} from "../auth/auth.service";
-import {MatMenuModule} from "@angular/material/menu";
-import {MatProgressBar} from "@angular/material/progress-bar";
+import {
+  AfterViewInit,
+  Component,
+  inject,
+  signal,
+  ViewChild,
+} from '@angular/core';
+import { MatDrawer, MatSidenavModule } from '@angular/material/sidenav';
+import {
+  ArcgisMap,
+  ComponentLibraryModule,
+} from '@arcgis/map-components-angular';
+import { ArcgisMapCustomEvent } from '@arcgis/map-components';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import {
+  SelectionCriteria,
+  SelectionCriteriaComponent,
+} from './selection-criteria/selection-criteria.component';
+import { ReefGuideApiService } from './reef-guide-api.service';
+import { MatTooltip } from '@angular/material/tooltip';
+import { MatDialog } from '@angular/material/dialog';
+import { ConfigDialogComponent } from './config-dialog/config-dialog.component';
+import { ReefGuideConfigService } from './reef-guide-config.service';
+import { AsyncPipe, CommonModule } from '@angular/common';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { LayerStyleEditorComponent } from '../widgets/layer-style-editor/layer-style-editor.component';
+import { ReefGuideMapService } from './reef-guide-map.service';
+import { MatAccordion, MatExpansionModule } from '@angular/material/expansion';
+import { LoginDialogComponent } from '../auth/login-dialog/login-dialog.component';
+import { AuthService } from '../auth/auth.service';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatProgressBar } from '@angular/material/progress-bar';
+import { AdminPanelComponent } from '../admin/admin-panel/admin-panel.component';
 
 type DrawerModes = 'criteria' | 'style';
 
@@ -31,6 +44,7 @@ type DrawerModes = 'criteria' | 'style';
   selector: 'app-location-selection',
   standalone: true,
   imports: [
+    CommonModule,
     MatSidenavModule,
     ComponentLibraryModule,
     MatButtonModule,
@@ -44,11 +58,11 @@ type DrawerModes = 'criteria' | 'style';
     MatAccordion,
     MatExpansionModule,
     MatMenuModule,
-    MatProgressBar
+    MatProgressBar,
   ],
   providers: [ReefGuideMapService],
   templateUrl: './location-selection.component.html',
-  styleUrl: './location-selection.component.scss'
+  styleUrl: './location-selection.component.scss',
 })
 export class LocationSelectionComponent implements AfterViewInit {
   readonly config = inject(ReefGuideConfigService);
@@ -62,15 +76,14 @@ export class LocationSelectionComponent implements AfterViewInit {
   @ViewChild(ArcgisMap) map!: ArcgisMap;
   @ViewChild('drawer') drawer!: MatDrawer;
 
-  constructor() {
-  }
+  constructor() {}
 
   ngAfterViewInit() {
     this.mapService.setMap(this.map);
   }
 
   async arcgisViewClick(event: ArcgisMapCustomEvent<__esri.ViewClickEvent>) {
-    console.log("arcgis map click", event);
+    console.log('arcgis map click', event);
     // const view = this.map.view;
     // const resp = await view.hitTest(event.detail);
   }
@@ -81,6 +94,12 @@ export class LocationSelectionComponent implements AfterViewInit {
     }
     this.drawerMode.set(mode);
     this.drawer.toggle(true);
+  }
+
+  openAdminPanel() {
+    this.dialog.open(AdminPanelComponent, {
+      width: '800px',
+    });
   }
 
   openConfig() {
@@ -99,10 +118,10 @@ export class LocationSelectionComponent implements AfterViewInit {
     this.mapService.clearAssessedLayers();
 
     const layerTypes = this.config.assessLayerTypes();
-    if (layerTypes.includes("cog")) {
+    if (layerTypes.includes('cog')) {
       this.mapService.addCOGLayers(criteria);
     }
-    if (layerTypes.includes("tile")) {
+    if (layerTypes.includes('tile')) {
       this.mapService.addTileLayers(criteria);
     }
   }

--- a/src/app/location-selection/location-selection.component.ts
+++ b/src/app/location-selection/location-selection.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, CommonModule } from '@angular/common';
+import {AsyncPipe, CommonModule} from '@angular/common';
 import {
   AfterViewInit,
   Component,
@@ -6,33 +6,33 @@ import {
   signal,
   ViewChild,
 } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { MatButtonModule } from '@angular/material/button';
-import { MatDialog } from '@angular/material/dialog';
-import { MatAccordion, MatExpansionModule } from '@angular/material/expansion';
-import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatProgressBar } from '@angular/material/progress-bar';
-import { MatProgressSpinner } from '@angular/material/progress-spinner';
-import { MatDrawer, MatSidenavModule } from '@angular/material/sidenav';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatTooltip } from '@angular/material/tooltip';
-import { ArcgisMapCustomEvent } from '@arcgis/map-components';
+import {toObservable} from '@angular/core/rxjs-interop';
+import {MatButtonModule} from '@angular/material/button';
+import {MatDialog} from '@angular/material/dialog';
+import {MatAccordion, MatExpansionModule} from '@angular/material/expansion';
+import {MatIconModule} from '@angular/material/icon';
+import {MatMenuModule} from '@angular/material/menu';
+import {MatProgressBar} from '@angular/material/progress-bar';
+import {MatProgressSpinner} from '@angular/material/progress-spinner';
+import {MatDrawer, MatSidenavModule} from '@angular/material/sidenav';
+import {MatToolbarModule} from '@angular/material/toolbar';
+import {MatTooltip} from '@angular/material/tooltip';
+import {ArcgisMapCustomEvent} from '@arcgis/map-components';
 import {
   ArcgisMap,
   ComponentLibraryModule,
 } from '@arcgis/map-components-angular';
-import { combineLatest, map, Observable, of, switchMap } from 'rxjs';
-import { AdminPanelComponent } from '../admin/admin-panel/admin-panel.component';
-import { AuthService } from '../auth/auth.service';
-import { LoginDialogComponent } from '../auth/login-dialog/login-dialog.component';
-import { LayerStyleEditorComponent } from '../widgets/layer-style-editor/layer-style-editor.component';
-import { ConfigDialogComponent } from './config-dialog/config-dialog.component';
-import { ReefGuideApiService } from './reef-guide-api.service';
-import { CriteriaAssessment } from './reef-guide-api.types';
-import { ReefGuideConfigService } from './reef-guide-config.service';
-import { ReefGuideMapService } from './reef-guide-map.service';
-import { SelectionCriteriaComponent } from './selection-criteria/selection-criteria.component';
+import {combineLatest, map, Observable, of, switchMap} from 'rxjs';
+import {AdminPanelComponent} from '../admin/admin-panel/admin-panel.component';
+import {AuthService} from '../auth/auth.service';
+import {LoginDialogComponent} from '../auth/login-dialog/login-dialog.component';
+import {LayerStyleEditorComponent} from '../widgets/layer-style-editor/layer-style-editor.component';
+import {ConfigDialogComponent} from './config-dialog/config-dialog.component';
+import {ReefGuideApiService} from './reef-guide-api.service';
+import {CriteriaAssessment} from './reef-guide-api.types';
+import {ReefGuideConfigService} from './reef-guide-config.service';
+import {ReefGuideMapService} from './reef-guide-map.service';
+import {SelectionCriteriaComponent} from './selection-criteria/selection-criteria.component';
 
 type DrawerModes = 'criteria' | 'style';
 
@@ -85,9 +85,9 @@ export class LocationSelectionComponent implements AfterViewInit {
     this.isAssessing$ = combineLatest([
       toObservable(this.mapService.siteSuitabilityLoading),
       toObservable(this.mapService.criteriaRequest).pipe(
-        switchMap((cr) => {
+        switchMap(cr => {
           if (cr) {
-            return cr.busyRegions$.pipe(map((r) => r.size > 0));
+            return cr.busyRegions$.pipe(map(r => r.size > 0));
           } else {
             return of(false);
           }
@@ -95,7 +95,7 @@ export class LocationSelectionComponent implements AfterViewInit {
       ),
     ]).pipe(
       // any busy
-      map((vals) => vals.includes(true))
+      map(vals => vals.includes(true))
     );
   }
 
@@ -141,7 +141,7 @@ export class LocationSelectionComponent implements AfterViewInit {
    * @param assessment
    */
   onAssess(assessment: CriteriaAssessment) {
-    const { criteria, siteSuitability } = assessment;
+    const {criteria, siteSuitability} = assessment;
 
     this.mapService.clearAssessedLayers();
 

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,5 +1,5 @@
 export const environment = {
-  reefGuideApiUrl: 'http://localhost:4200/reef-guide-api',
-  adriaApiUrl: 'http://localhost:4200/adria-api',
-  webApiUrl: 'http://localhost:5000/api'
+  reefGuideApiUrl: 'https://guide-api.reefguide.mds.gbrrestoration.org',
+  adriaApiUrl: 'http://localhost:4200/adria-guide-api',
+  webApiUrl: 'http://localhost:5000/api',
 };


### PR DESCRIPTION
Implements a prototype user management panel which 

- lists users in a table
- allows you to delete, create new users, update passwords and edit roles (of which there is currently only one 'ADMIN')

**Disclaimer** I 'co-developed' with Claude AI on this and it's my first time working with Angular, would appreciate a more comprehensive review which points out any anti-patterns/simpler way of doing things. 

Cheers.